### PR TITLE
個人タスク画面のレンダリング，タスク詳細での時刻の表示，時刻（date型）に従って並び替え

### DIFF
--- a/chatapp/app.js
+++ b/chatapp/app.js
@@ -9,6 +9,9 @@ const session = require('express-session');
 const bodyParser = require('body-parser');
 const nodemon = require("nodemon");
 const routes = require('./routes/index');
+// date関連
+require('date-utils');
+
 
 const app = express();
 
@@ -31,6 +34,19 @@ hbs.handlebars.registerHelper('evenNumberChecker', function(num) {
 hbs.handlebars.registerHelper('unixtimeToDate', function(unixtime, format) {
   return (new Date(unixtime).toFormat(format));
 });
+
+/**
+ * DBへ保存する際のtimezoneによる時間のずれを戻す
+ * 具体的にはJSTで登録したのにUTCとしてDBが認識するのでJST（UTC+9）として表示すると
+ * 実際の時間よりもこの+9が逆に邪魔する
+ * これを-9時間（マイクロ秒なので1000 * 60 * 60 * 9）戻して修正する
+ *  */ 
+hbs.handlebars.registerHelper('timeConverter', function(time, format) {
+  let UTC = new Date(time)
+  UTC.setTime(UTC.getTime() - 1000 * 60 * 60 * 9)
+  return UTC.toFormat(format);
+});
+
 // 二つの値が等しいかどうかの真偽値を返す
 hbs.handlebars.registerHelper('isEquals', function(num1, num2) {
   return num1===num2;

--- a/chatapp/config/config.json
+++ b/chatapp/config/config.json
@@ -6,7 +6,6 @@
     "host": "127.0.0.1",
     "dialect": "sqlite",
     "storage": "./db/development.sqlite3"
-
   },
   "test": {
     "username": "root",

--- a/chatapp/controller/userController.js
+++ b/chatapp/controller/userController.js
@@ -25,9 +25,13 @@ let userController = {
                  * #2
                  * 次に結合後の中の何かで並べ替えるときは
                  * そのモデルをindex0，対象をindex1，オプションをindex2に記述することでソートが可能
-                 * タスクの場合，締め切りが早いものを一番上に表示させたいのでDESCにする．
+                 * 
+                 * 
+                 * だと．おもっているのですが，ちゃんと並べ替えられるものとられないものがあって半泣きです．
+                 * 個人タスクでも同様に並び替えられるものと並び替えられないものがいてギャン泣きです，
+                 * ASCをDESCにすると逆に並び替えられていなかったものが並び変わります．なぜでしょう．．．
                  */
-                order: [["id", 'ASC'], ['desTask', "deadline", 'DESC']],
+                order: [["id", 'ASC'], ['desTask', "deadline", 'ASC']],
             }).then(users => {
                 if (!users) {
                     console.log("ユーザーデータを取得できませんでした");
@@ -58,10 +62,11 @@ let userController = {
                         include: {
                             model: dbModels.User,
                             as: 'reqUser'
-                        }
-                        
+                        }   
                     }
-                ]
+                ],
+                // なぜなんだぁ
+                order: [['desTask', "deadline", 'ASC']],
             }).then(user_with_desTask => {
                 if (!user_with_desTask) {
                     console.log("ユーザーデータを取得できませんでした");
@@ -79,7 +84,9 @@ let userController = {
                                     as: 'desUser'
                                 }
                             }
-                        ]
+                        ],
+                        // なぜだぁ．．．
+                        order: [['reqTask', "deadline", 'ASC']],
                     }).then(user_with_reqTask => {
                         if (!user_with_reqTask) {
                             console.log("ユーザーデータを取得できませんでした");

--- a/chatapp/public/stylesheets/task_style.css
+++ b/chatapp/public/stylesheets/task_style.css
@@ -8,7 +8,15 @@
 
 .card {
     margin: 1em;
+    /* background-color: PaleVioletRed; */
+}
+
+.destination_user_card {
     background-color: PaleVioletRed;
+}
+
+.request_user_card {
+    background-color: DodgerBlue;
 }
 
 .card-header {

--- a/chatapp/routes/index.js
+++ b/chatapp/routes/index.js
@@ -6,7 +6,6 @@ const userController = require('../controller/userController');
 const taskController = require('../controller/taskController');
 const { render } = require('../app');
 const router = express.Router();
-require('date-utils');
 
 // ログイン画面の表示
 router.get('/', function (request, response, next) {
@@ -22,13 +21,7 @@ router.get('/', function (request, response, next) {
 router.post('/user', userController.loginByName);
 
 // チャット退出後→個人一覧画面(データベースで情報取得の必要性がないためGET)
-router.get('/user', function (request, response, next) {
-    if (request.session.user === undefined) {
-        response.redirect('/');
-    } else {
-        response.render('user', { userName: request.session.username, id: request.session.userid });
-    }
-});
+router.get('/user', userController.showUsersTasks);
 
 // チャット画面の表示
 router.get('/room', function (request, response, next) {

--- a/chatapp/seeders/20200909063013-seed-task.js
+++ b/chatapp/seeders/20200909063013-seed-task.js
@@ -12,11 +12,14 @@ module.exports = {
      * }], {});
     */
 
+
+    // 期限のフォーマット:yyyy-mm-dd hh:mm:ss
     await queryInterface.bulkInsert('Tasks', [{
       title: '会社A訪問',
       info: '会社Aのりんごさんに新商品のプレゼン',
       reqUserId: 1,
       desUserId: 2,
+      deadline: '2020-9-10 12:00:00',
       done: 0
     }], {});
 
@@ -25,6 +28,7 @@ module.exports = {
       info: '会社Bのりんごさんに新商品のプレゼン',
       reqUserId: 1,
       desUserId: 2,
+      deadline: '2020-9-9 12:00:00',
       done: 0
     }], {});
 
@@ -33,6 +37,7 @@ module.exports = {
       info: '会社Cのりんごさんに新商品のプレゼン',
       reqUserId: 2,
       desUserId: 1,
+      deadline: '2020-9-8 12:00:00',
       done: 0
     }], {});
 
@@ -42,6 +47,7 @@ module.exports = {
       info: 'SPADイメージングの論文を執筆し学会に寄稿する',
       reqUserId: 3,
       desUserId: 1,
+      deadline: '2020-9-14 18:00:00',
       done: 0
     }], {});
 
@@ -51,15 +57,17 @@ module.exports = {
       info: '新規プロジェクトであるXXXを立ち上げる',
       reqUserId: 2,
       desUserId: 3,
+      deadline: '2020-10-1 12:00:00',
       done: 0
     }], {});
     
     // sample4
     await queryInterface.bulkInsert('Tasks', [{
       title: 'Word2Vecの導入',
-      info: '現在のシステムで蓄積された文章コーパスを用いて単語を分散表現を獲得する',
+      info: '現在のシステムで蓄積された文章コーパスを用いて単語の分散表現を獲得する',
       reqUserId: 4,
       desUserId: 5,
+      deadline: '2020-9-17 15:00:00',
       done: 0
     }], {});
 
@@ -69,6 +77,7 @@ module.exports = {
       info: '現在システムで採用している音声認識技術の性能向上を行う．',
       reqUserId: 4,
       desUserId: 6,
+      deadline: '2020-9-15 13:00:00',
       done: 0
     }], {});
 
@@ -78,6 +87,7 @@ module.exports = {
       info: '現在のシステムで蓄積されたデータを扱いやすいように整形する．',
       reqUserId: 5,
       desUserId: 6,
+      deadline: '2020-9-17 15:00:00',
       done: 0
     }], {});
   },

--- a/chatapp/views/task.hbs
+++ b/chatapp/views/task.hbs
@@ -1,128 +1,128 @@
 <div class="container">
     <div class="box">
-    <h3 class=" text-center">全タスク一覧</h3>
+    <h3 class=" text-center">全ユーザのタスク一覧</h3>
         <div class="inbox">
-            {{!-- <form method="post" action="/"> --}}
-                <div class="inbox_menus">
-                    <div class="inbox_menu">
-                        <div class="menu_list active_menu">
-                            <div class="menu_user">
-                                <div class="user_img"> <img src="https://ptetutorials.com/images/user-profile.png"
-                                        alt="sunil"> </div>
-                                <div class="user_ib">
-                                    <h5>User：{{user.name}}
-                                        <input id="userName" value={{user.name}} type="hidden" value="">
-                                    </h5>
-                                </div>
+            <div class="inbox_menus">
+                <div class="inbox_menu">
+                    <div class="menu_list active_menu">
+                        <div class="menu_user">
+                            <div class="user_img"> <img src="https://ptetutorials.com/images/user-profile.png"
+                                    alt="sunil"> </div>
+                            <div class="user_ib">
+                                <h5>User：{{userName}}
+                                    <input id="userName" value={{userName}} type="hidden" value="">
+                                </h5>
                             </div>
                         </div>
-                        <div class="menu_list active_menu text-center">
-                            <a href="/user" class="btn btn-raised btn-info">個人タスク</a>
-                        </div>
-                        <div class="menu_list active_menu text-center">
-                            <a href="/room" class="btn btn-raised btn-success">全体チャット</a>
-                        </div>
-                        <div class="menu_list active_menu text-center">
-                            <a href="/task" class="btn btn-raised btn-success">全体タスク</a>
-                        </div>
-                        <div class="menu_list active_menu text-center">
-                            <button type="button" class="btn btn-primary bmd-btn-fab bmd-btn-fab-sm">
-                                <i class="fas fa-plus"></i>
-                            </button>
-                        </div>
-                        <div class="menu_list active_menu text-center">
-                            <a href="/" class="btn btn-raised btn-danger">ログアウト</a>
-                        </div>
+                    </div>
+                    <div class="menu_list active_menu text-center">
+                        <a href="/user" class="btn btn-raised btn-info">個人タスク</a>
+                    </div>
+                    <div class="menu_list active_menu text-center">
+                        <a href="/room" class="btn btn-raised btn-success">全体チャット</a>
+                    </div>
+                    <div class="menu_list active_menu text-center">
+                        <a href="/task" class="btn btn-raised btn-success">全体タスク</a>
+                    </div>
+                    <div class="menu_list active_menu text-center">
+                        <button type="button" class="btn btn-primary bmd-btn-fab bmd-btn-fab-sm">
+                            <i class="fas fa-plus"></i>
+                        </button>
+                    </div>
+                    <div class="menu_list active_menu text-center">
+                        <a href="/" class="btn btn-raised btn-danger">ログアウト</a>
                     </div>
                 </div>
-                <div id="contents" class="task_contents">
-                    <div class="task_contents_box text-center">
-                        {{#each user}}
-                        {{#with dataValues}}
-                            {{!-- 行区切り（2ユーザごとにrowを代入） --}}
-                            {{#unless (evenNumberChecker id)}}
-                                <div class="row">
-                            {{/unless}}
-                            {{!-- 列区切り（ユーザごとのタスク） --}}
-                                <div class="col user_task">
-                                    <div class="h5 text-left">
-                                        <strong><u>@{{ name }}</u></strong>
-                                    </div>
-                                    <div id="accordion_user{{id}}">
-                                    {{!-- ユーザがタスクを持っているか -> リストが空なら持っていない --}}
-                                    {{#unless desTask}}
-                                        <div class="card text-white bg-primary">
-                                            <div class="card-header" id="user{{ id }}_no_task">
-                                                <h5 class="mb-0">
-                                                    進行中のタスクはありません
-                                                </h5>
-                                            </div>
+            </div>
+            <div id="contents" class="task_contents">
+                <div class="task_contents_box text-center">
+                    {{#each user}}
+                    {{#with dataValues}}
+                        {{!-- 行区切り（2ユーザごとにrowを代入） --}}
+                        {{#unless (evenNumberChecker id)}}
+                            <div class="row">
+                        {{/unless}}
+                        {{!-- 列区切り（ユーザごとのタスク） --}}
+                            <div class="col user_task">
+                                <div class="h5 text-left">
+                                    <strong><u>@{{ name }}</u></strong>
+                                </div>
+                                <div id="accordion_user{{id}}">
+                                {{!-- ユーザがタスクを持っているか -> リストが空なら持っていない --}}
+                                {{#unless desTask}}
+                                    <div class="card text-white bg-primary">
+                                        <div class="card-header" id="user{{ id }}_no_task">
+                                            <h5 class="mb-0">
+                                                進行中のタスクはありません
+                                            </h5>
                                         </div>
-                                    {{!-- タスクを持っているとき --}}
-                                    {{else}}
-                                        {{#each desTask}}
-                                        {{!-- すみません，これ以降のidはタスクIDを指します．ユーザIDはeachを含め2階層上です． --}}
-                                        {{#with dataValues}}
-                                        <div class="card text-white">
-                                            <div class="card-header" id="user{{../../id}}_task_{{id}}">
-                                                <h5 class="mb-0">
-                                                    <div class="row">
-                                                        <button class="btn btn-light btn-secondary" type="button" data-toggle="collapse" data-target="#collapse_user{{../../id}}_task_{{id}}" aria-expanded="false" aria-controls="collapse_user{{../../id}}_task_{{id}}">
+                                    </div>
+                                {{!-- タスクを持っているとき --}}
+                                {{else}}
+                                    {{#each desTask}}
+                                    {{!-- すみません，これ以降のidはタスクIDを指します．ユーザIDはeachを含め2階層上です． --}}
+                                    {{#with dataValues}}
+                                    <div class="card text-white destination_user_card">
+                                        <div class="card-header" id="user{{../../id}}_task_{{id}}">
+                                            <h5 class="mb-0">
+                                                <div class="row">
+                                                    <button class="btn btn-light btn-secondary" type="button" data-toggle="collapse" data-target="#collapse_user{{../../id}}_task_{{id}}" aria-expanded="false" aria-controls="collapse_user{{../../id}}_task_{{id}}">
 
-                                                        <div class="text-left">
-                                                        <p class='h6'>タスク名</p>
-                                                        {{!-- <p class="h4"><u>{{title}}</u></p> --}}
-                                                        <p class="h5">{{title}}</p>
+                                                    <div class="text-left">
+                                                    <p class='h6'>タスク名</p>
+                                                    {{!-- <p class="h4"><u>{{title}}</u></p> --}}
+                                                    <p class="h5">{{title}}</p>
 
-                                                        </div>
-                                                        </button>
-
-                                                        <div class="task_status">
-                                                        <p><u><small>
-                                                        {{#if done}}
-                                                            タスク完了
-                                                        {{else}}
-                                                            タスク未完了
-                                                        {{/if}}
-                                                        </small></u></p>
-                                                        </div>
                                                     </div>
-                                                </h5>
-                                            </div>
+                                                    </button>
 
-                                            <div id="collapse_user{{../../id}}_task_{{id}}" class="collapse" aria-labelledby="user{{../../id}}_task_{{id}}" data-parent="#accordion_user{{id}}">
+                                                    <div class="task_status">
+                                                    <p><u><small>
+                                                    {{#if done}}
+                                                        タスク完了
+                                                    {{else}}
+                                                        タスク未完了
+                                                    {{/if}}
+                                                    </small></u></p>
+                                                    </div>
+                                                </div>
+                                            </h5>
+                                        </div>
+
+                                        <div id="collapse_user{{../../id}}_task_{{id}}" class="collapse" aria-labelledby="user{{../../id}}_task_{{id}}" data-parent="#accordion_user{{id}}">
                                             <div class="card-body text-left bg-light text-dark">
                                                 <h5><u>概要</u></h5>
                                                 <ul>
                                                 <li>タスク名：{{title}}</li>
-                                                {{!-- ここの時間も．．． --}}
-                                                <li>タスク期限：2020年9月11日12時</li>
-                                                {{!-- <li>タスク期限：{{unixtimeToDate date 'YYYY年 M月D日 HH24:MI:SS'}}</li> --}}
-                                                {{!-- ここ名前で持ってきたい --}}
-                                                <li>タスク依頼者：{{reqUserId}}</li>
+                                                {{!-- Date型を使う場合SQliteがUTCしか扱っていないので登録した時間をUTCと認識する．そうするとJSTで+9時間足された時間は実際の登録時間よりも+9時間さらにずれているということになる．なので関数側でこのズレを戻して表示する．この時formatも指定する --}}
+                                                <li>タスク期限：
+                                                    {{timeConverter  deadline 'YYYY年 M月D日 HH24:MI:SS'}}</li>
+                                                {{#with reqUser.dataValues}}
+                                                <li>タスク依頼者：{{name}}</li>
+                                                {{/with}}
                                                 </ul>
                                                 <h5><u>タスク詳細</u></h5>
                                                 <p>{{info}}</p>
                                             </div>
-                                            </div>
                                         </div>
-                                        {{/with}}
-                                        {{/each}}
-                                    {{/unless}}
-
                                     </div>
+                                    {{/with}}
+                                    {{/each}}
+                                {{/unless}}
+
                                 </div>
-                            {{#if (evenNumberChecker id)}}
                             </div>
-                            {{/if}}
-                        {{/with}}
-                        {{/each}}
+                        {{#if (evenNumberChecker id)}}
+                        </div>
+                        {{/if}}
+                    {{/with}}
+                    {{/each}}
                     </div>
-                </div>
             </div>
-         </div>
+        </div>
         <p class="text-center top_spac"> ©︎ Copylight Rakus Intern A-team All Rights Reserved.</p>
     </div>
+    {{!-- </div> --}}
 </div>
 {{!-- <script src="/javascripts/task.js"></script> --}}
 <link rel="stylesheet" href="/stylesheets/task_style.css" />

--- a/chatapp/views/user.hbs
+++ b/chatapp/views/user.hbs
@@ -1,180 +1,204 @@
 <div class="container">
     <div class="box">
-    <h3 class=" text-center">user-task</h3>
+    <h3 class=" text-center"><strong>{{userName}}</strong>さんのタスク一覧</h3>
         <div class="inbox">
-            <form method="post" action="/">
-                <div class="inbox_menus">
-                    <div class="inbox_menu">
-                        <div class="menu_list active_menu">
-                            <div class="menu_user">
-                                <div class="user_img"> <img src="https://ptetutorials.com/images/user-profile.png"
-                                        alt="sunil"> </div>
-                                <div class="user_ib">
-                                    <h5>User：{{user.name}}
-                                        <input id="userName" value={{user.name}} type="hidden" value="">
-                                    </h5>
-                                </div>
+            <div class="inbox_menus">
+                <div class="inbox_menu">
+                    <div class="menu_list active_menu">
+                        <div class="menu_user">
+                            <div class="user_img"> <img src="https://ptetutorials.com/images/user-profile.png"
+                                    alt="sunil"> </div>
+                            <div class="user_ib">
+                                <h5>User：{{userName}}
+                                    <input id="userName" value={{userName}} type="hidden" value="">
+                                </h5>
                             </div>
                         </div>
-                        <div class="menu_list active_menu text-center">
-                            <a href="/user" class="btn btn-raised btn-info">個人タスク</a>
-                        </div>
-                        <div class="menu_list active_menu text-center">
-                            <a href="/room" class="btn btn-raised btn-success">全体チャット</a>
-                        </div>
-                        <div class="menu_list active_menu text-center">
-                            <a href="/task" class="btn btn-raised btn-success">全体タスク</a>
-                        </div>
-                        <div class="menu_list active_menu text-center">
-                            <button type="button" class="btn btn-primary bmd-btn-fab bmd-btn-fab-sm">
-                                <i class="fas fa-plus"></i>
-                            </button>
-                        </div>
-                        <div class="menu_list active_menu text-center">
-                            <a href="/" class="btn btn-raised btn-danger">ログアウト</a>
-                        </div>
+                    </div>
+                    <div class="menu_list active_menu text-center">
+                        <a href="/user" class="btn btn-raised btn-info">個人タスク</a>
+                    </div>
+                    <div class="menu_list active_menu text-center">
+                        <a href="/room" class="btn btn-raised btn-success">全体チャット</a>
+                    </div>
+                    <div class="menu_list active_menu text-center">
+                        <a href="/task" class="btn btn-raised btn-success">全体タスク</a>
+                    </div>
+                    <div class="menu_list active_menu text-center">
+                        <button type="button" class="btn btn-primary bmd-btn-fab bmd-btn-fab-sm">
+                            <i class="fas fa-plus"></i>
+                        </button>
+                    </div>
+                    <div class="menu_list active_menu text-center">
+                        <a href="/" class="btn btn-raised btn-danger">ログアウト</a>
                     </div>
                 </div>
+            </div>
 
-                <div id="contents" class="task_contents">
-                    <div class="task_contents_box">
-                        <div class="row task_row">
-                         {{!-- 受け取ったタスク --}}
-                        <div class='col mini_task'>
-                            <div class='accordion' id="user{{id}}_desTask">
-                                {{!-- 受け取ったタスクがない場合 --}}
-                                {{#unless hasDesTask}}
-                                <div class="card text-white bg-secondary">
-                                    <div class="card-header" id="user{{ id }}_desTask">
-                                        <h5 class="mb-0 text-center">
-                                            <label>進行中のタスクはありません．</label>
-                                        </h5>
-                                    </div>
-                                </div>
-                                {{else}}
-                                {{!-- 一気に描画する --}}
-                                {{#each desTask}}
-                                {{#if done}}
-                                    <div class="card text-white bg-primary">
-                                {{else}}
-                                    <div class="card text-white bg-danger">
-                                {{/if}}
-                                        <div class="card-header" id="user{{../id}}_desTask_{{title}}">
-                                            <h5 class="mb-0">
-                                                <div class="row">
-                                                    <div class='col-6 text-center'>
-                                                    タスク名：{{title}}
-                                                    </div>
-                                                    <div class='col-4'>
-                                                        <button class="btn btn-light collapsed　btn-secondary" type="button"
-                                                            data-toggle="collapse" data-target="#user{{../id}}_collapse_{{title}}"
-                                                            aria-expanded="false" aria-controls="user{{../id}}_collapse_{{title}}">
-                                                            <p>
-                                                                {{#if done}}
-                                                                タスク完成：{{done}}
-                                                                {{else}}
-                                                                タスク未完成：{{done}}
-                                                                {{/if}}
-                                                            </p>
-                                                        </button>
-                                                    </div>
-                                                </div>
-                                            </h5>
-                                        </div>
-
-                                        <div id="user{{../id}}_collapse_{{title}}" class="collapse"
-                                            aria-labelledby="user{{../id}}_desTask_{{title}}" data-parent="#user{{../id}}_all_desTask">
-                                            <div class="card-body">
-                                                <p>ユーザ{{../id}}のタスク</p>
-                                                
-                                                <ul>
-                                                    <p>タスク名：{{title}}</p>
-                                                    <p>タスク期限：{{unixtimeToDate date 'YYYY年 M月D日 HH24:MI:SS'}}</p>
-                                                    <p>タスク依頼者：{{req}}</p>
-                                                    <p>タスク依頼先：{{des}}</p>
-                                                    <p>タスク情報：{{info}}</p>
-                                                </ul>
+            {{!-- 持っているタスクを全部カードで表示，この時全部Openにする --}}
+            <div id="contents" class="task_contents">
+                <div class="task_contents_box text-center">
+                    <div class='row'>
+                        {{!-- 受け取ったタスク列 --}}
+                        <div class="col user_task">
+                            <div class="h5 text-center">
+                                <p><strong><u>受け取ったタスク</u></strong></p>
+                            </div>
+                            
+                            {{#with user_with_desTask.dataValues}}
+                                {{!-- タスクを持っているか判定 -> リストが空なら持っていないので持ってないカード発行 --}}
+                                {{#unless desTask}}
+                                    {{!-- 空なのでtaskID無し --}}
+                                    <div id="accordion_user{{id}}_no_desTask">
+                                        <div class="card text-white bg-primary">
+                                            <div class="card-header" id="user{{ id }}_no_desTask">
+                                                <h5 class="mb-0">
+                                                    依頼されたタスクはありません
+                                                </h5>
                                             </div>
                                         </div>
                                     </div>
-                                {{/each}}
-                                {{/unless}}
-                            </div>
-                        </div>
-                        
-                        {{!-- 送ったタスク --}}
-                        <div class='col mini_task'>
-                            <div class='accordion' id="user{{id}}_reqTask">
-                            {{!-- 送ったタスクがない場合 --}}
-                                {{#unless hasReqTask}}
-                                <div class="card text-white">
-                                    <div class="card-header" id="user{{ id }}_no_reqTask">
-                                        <h5 class="mb-0 text-center">
-                                            <label>依頼中のタスクはありません．</label>
-                                        </h5>
-                                    </div>
-                                </div>
+                                {{!-- タスクを持っているとき --}}
                                 {{else}}
-                                {{!-- 一気に描画する --}}
-                                {{#each reqTask}}
-                                {{#if done}}
-                                    <div class="card text-white bg-primary">
-                                {{else}}
-                                    <div class="card text-white bg-danger">
-                                {{/if}}
-                                        <div class="card-header" id="user{{../id}}_reqTask_{{title}}">
-                                            <h5 class="mb-0">
-                                                <div class="row">
-                                                    <div class='col-6 text-center'>
-                                                    タスク名：{{title}}
-                                                    </div>
-                                                    <div class='col-4'>
-                                                        <button class="btn btn-light collapsed　btn-secondary" type="button"
-                                                            data-toggle="collapse" data-target="#user{{../id}}_collapse_{{title}}"
-                                                            aria-expanded="false" aria-controls="user{{../id}}_collapse_{{title}}">
-                                                            <p>
-                                                                {{#if done}}
-                                                                タスク完成：{{done}}
-                                                                {{else}}
-                                                                タスク未完成：{{done}}
-                                                                {{/if}}
-                                                            </p>
-                                                        </button>
-                                                    </div>
-                                                </div>
-                                            </h5>
-                                        </div>
 
-                                        <div id="user{{../id}}_collapse_{{title}}" class="collapse"
-                                            aria-labelledby="user{{../id}}_reqTask_{{title}}" data-parent="#user{{../id}}_all_reqTask">
-                                            <div class="card-body">
-                                                <p>ユーザ{{../id}}のタスク</p>
-                                                
-                                                <ul>
-                                                    <p>タスク名：{{title}}</p>
-                                                    <p>タスク期限：{{unixtimeToDate date 'YYYY年 M月D日 HH24:MI:SS'}}</p>
-                                                    <p>タスク依頼者：{{req}}</p>
-                                                    <p>タスク依頼先：{{des}}</p>
-                                                    <p>タスク情報：{{info}}</p>
-                                                </ul>
+                                    {{#each desTask}}
+                                    {{#with dataValues}}
+                                    <div id="accordion_user{{../../id}}_task_{{id}}">
+                                        <div class="card text-white destination_user_card">
+                                            <div class="card-header" id="user{{../../id}}_task_{{id}}">
+                                                <h5 class="mb-0">
+                                                    <div class="row">
+                                                        <button class="btn btn-light btn-secondary" type="button" data-toggle="collapse" data-target="#collapse_user{{../../id}}_task_{{id}}" aria-expanded="true" aria-controls="collapse_user{{../../id}}_task_{{id}}">
+
+                                                        <div class="text-left">
+                                                        <p class='h6'>タスク名</p>
+                                                        {{!-- <p class="h4"><u>{{title}}</u></p> --}}
+                                                        <p class="h5">{{title}}</p>
+
+                                                        </div>
+                                                        </button>
+
+                                                        <div class="task_status">
+                                                        <p><u><small>
+                                                        {{#if done}}
+                                                            タスク完了
+                                                        {{else}}
+                                                            タスク未完了
+                                                        {{/if}}
+                                                        </small></u></p>
+                                                        </div>
+                                                    </div>
+                                                </h5>
+                                            </div>
+                                        
+                                            <div id="collapse_user{{../../id}}_task_{{id}}" class="collapse show" aria-labelledby="user{{../../id}}_task_{{id}}" data-parent="#accordion_user{{../../id}}_task_{{id}}">
+                                                <div class="card-body text-left bg-light text-dark">
+                                                    <h5><u>概要</u></h5>
+                                                    <ul>
+                                                    <li>タスク名：{{title}}</li>
+                                                    {{!-- Date型を使う場合SQliteがUTCしか扱っていないので登録した時間をUTCと認識する．そうするとJSTで+9時間足された時間は実際の登録時間よりも+9時間さらにずれているということになる．なので関数側でこのズレを戻して表示する．この時formatも指定する --}}
+                                                    <li>タスク期限：
+                                                        {{timeConverter  deadline 'YYYY年 M月D日 HH24:MI:SS'}}</li>
+                                                    {{#with reqUser.dataValues}}
+                                                    <li>タスク依頼者：{{name}}</li>
+                                                    {{/with}}
+                                                    </ul>
+                                                    <h5><u>タスク詳細</u></h5>
+                                                    <p>{{info}}</p>
+                                                </div>
                                             </div>
                                         </div>
                                     </div>
-                                {{/each}}
+
+                                    {{/with}}
+                                    {{/each}}
                                 {{/unless}}
+                            {{/with}}
+
+
+                        </div>
+
+                        {{!-- 依頼したタスク列 -> 受け取ったときとほとんど同じコード --}}
+                        <div class="col user_task">
+                            <div class="h5 text-center">
+                                <p><strong><u>依頼したタスク</u></strong></p>
                             </div>
+
+                            {{#with user_with_reqTask.dataValues}}
+                                {{!-- タスクを持っているか判定 -> リストが空なら持っていないので持ってないカード発行 --}}
+                                {{#unless reqTask}}
+                                    <div id="accordion_user{{id}}_reqTask">
+                                        <div class="card text-white bg-primary">
+                                            <div class="card-header" id="user{{ id }}_no_reqTask">
+                                                <h5 class="mb-0">
+                                                    依頼したタスクはありません
+                                                </h5>
+                                            </div>
+                                        </div>
+                                    </div>
+                                {{!-- タスクを持っているとき --}}
+                                {{else}}
+                                    {{#each reqTask}}
+                                    {{#with dataValues}}
+                                    <div id="accordion_user{{../../id}}_task_{{id}}">
+                                        <div class="card text-white request_user_card">
+                                            <div class="card-header" id="user{{../../id}}_task_{{id}}">
+                                                <h5 class="mb-0">
+                                                    <div class="row">
+                                                        <button class="btn btn-light btn-secondary" type="button" data-toggle="collapse" data-target="#collapse_user{{../../id}}_task_{{id}}" aria-expanded="true" aria-controls="collapse_user{{../../id}}_task_{{id}}">
+
+                                                        <div class="text-left">
+                                                        <p class='h6'>タスク名</p>
+                                                        {{!-- <p class="h4"><u>{{title}}</u></p> --}}
+                                                        <p class="h5">{{title}}</p>
+
+                                                        </div>
+                                                        </button>
+
+                                                        <div class="task_status">
+                                                        <p><u><small>
+                                                        {{#if done}}
+                                                            タスク完了
+                                                        {{else}}
+                                                            タスク未完了
+                                                        {{/if}}
+                                                        </small></u></p>
+                                                        </div>
+                                                    </div>
+                                                </h5>
+                                            </div>
+                                        
+                                            <div id="collapse_user{{../../id}}_task_{{id}}" class="collapse show" aria-labelledby="user{{../../id}}_task_{{id}}" data-parent="#accordion_user{{../../id}}_task_{{id}}">
+                                                <div class="card-body text-left bg-light text-dark">
+                                                    <h5><u>概要</u></h5>
+                                                    <ul>
+                                                    <li>タスク名：{{title}}</li>
+                                                    {{!-- Date型を使う場合SQliteがUTCしか扱っていないので登録した時間をUTCと認識する．そうするとJSTで+9時間足された時間は実際の登録時間よりも+9時間さらにずれているということになる．なので関数側でこのズレを戻して表示する．この時formatも指定する --}}
+                                                    <li>タスク期限：
+                                                        {{timeConverter  deadline 'YYYY年 M月D日 HH24:MI:SS'}}</li>
+                                                    {{!-- <li>タスク期限：{{unixtimeToDate date 'YYYY年 M月D日 HH24:MI:SS'}}</li> --}}
+                                                    {{!-- ここ名前で持ってきたい --}}
+                                                    {{#with desUser.dataValues}}
+                                                    <li>タスク依頼者：{{name}}</li>
+                                                    {{/with}}
+                                                    </ul>
+                                                    <h5><u>タスク詳細</u></h5>
+                                                    <p>{{info}}</p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    {{/with}}
+                                    {{/each}}
+                                {{/unless}}
+                            {{/with}}
                         </div>
-                    </div>
-                                </div>
-                        </div>
+                     </div>
+                </div>
+            </div>
         </div>
-        </div>
-    </form>
-</div>
+        <p class="text-center top_spac"> ©︎ Copylight Rakus Intern A-team All Rights Reserved.</p>
+    </div>
 </div>
 
-{{!-- <p class="text-center top_spac"> rakus-intern-A-team</a></p> --}}
-<p class="text-center top_spac"> ©︎ Copylight Rakus Intern A-team All Rights Reserved.</a></p>
-
-</div>
-</div>
+<link rel="stylesheet" href="/stylesheets/task_style.css" />


### PR DESCRIPTION
# 個人タスク画面
要件通り，アクセスすると詳細画面がすぐにみれるようにカードを開けています．
初期状態を開いているだけなのでタスク名を押すと閉めることもできます．
また，タスクが少しキツキツなのをどうにかする必要がある気もします．現段階での色は適当です．一応受け取ったタスクが**PaleVioletRed**(全体タスク同様)，依頼したタスクには**DodgerBlue**，なにもタスクを持っていない場合はbootstrapsの**bg-primary**を当てています．

# タスク詳細画面に表示する時刻
## Date型で保存した時刻を指定のフォーマットで表示する．
sequelizeはtimezoneの指定をすれば何も考えずJST時刻を扱えるが，sequelizeでSqliteを使う場合timezoneは使えないため，UTCで保存されたと勝手に認識されます．
>Setting a custom timezone is not supported by SQLite, dates are always returned as UTC. Please remove the custom timezone parameter.

となるとレンダリングする際，JSTに変換するとさらに+9時間加算されてしまうという問題が発生しました．そのまま表示するだけでいいのにこの差を修正する必要がでてきたため，hbs用に時刻の差を修正しフォーマットに従って時刻を返す関数を``app.js``に追加しました．
## 並び替え
``userController.js``内にもコメントふってます．なんせDBそのものがあまり触ったことがなく，orderの指定がうまくいかないです．教えてください．．．